### PR TITLE
Small fix to the adapter

### DIFF
--- a/Model/Adapter/QuickPayAdapter.php
+++ b/Model/Adapter/QuickPayAdapter.php
@@ -92,7 +92,7 @@ class QuickPayAdapter
                 'currency' => $attributes['CURRENCY'],
             ];
 
-            $shippingAddress = $attributes['SHIPPING_ADDRESS'];
+            $shippingAddress = $attributes['SHIPPING_ADDRESS'] ?? $attributes['BILLING_ADDRESS'];
             $form['shipping_address'] = [];
             $form['shipping_address']['name'] = $shippingAddress->getFirstName() . " " . $shippingAddress->getLastName();
             $form['shipping_address']['street'] = $shippingAddress->getStreetLine1();


### PR DESCRIPTION
Without the null check for shipping address, an exception would be thrown and Magento would crash, but only if the product is virtual. Virtual products doesn't have a shipping address, only a billing address. Adding this null check makes the module compatible with Magento 2.2.6.